### PR TITLE
Update trainer.py

### DIFF
--- a/ubc_coref/trainer.py
+++ b/ubc_coref/trainer.py
@@ -251,7 +251,8 @@ class Trainer:
         graph = nx.Graph()
 
         # Pass the document through the model
-        spans, probs, embeds = self.model(doc)
+        with torch.no_grad():
+            spans, probs, embeds = self.model(doc)
 
         # Cluster found coreference links
         for i, span in enumerate(spans):


### PR DESCRIPTION
Free memory by not saving gradients while inference

I tried to evaluate the model on OntoNotes. However, the model encountered the CUDA out-of-memory issue with a 16GB GPU after evaluating over 200 documents. So I added a line to constrain the model to save gradients during inference, which worked in my environment.

https://discuss.pytorch.org/t/cuda-out-of-memory-when-using-model-to-make-predictions/39002/4